### PR TITLE
Bugfix Cellblock Report

### DIFF
--- a/src/uncategorized/cellblockReport.tw
+++ b/src/uncategorized/cellblockReport.tw
@@ -12,14 +12,6 @@
 <<if ($slaves[$i].assignment is "be confined in the cellblock")>>
 	<<if $seeImages == 1>><<SlaveArt $slaves[$i] 0 0>><</if>>
 	<<set $cellblockSlaves += 1>>
-	<<silently>>
-	<<display [[SA stay confined]]>>
-	<<display "SA diet">>
-	<<display "SA long term effects">>
-	<<display "SA drugs">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
-	<</silently>>
 	<<if ($slaves[$i].devotion <= 20)>>
 	<<if ($slaves[$i].trust > -20)>>
 		<<set $slaves[$i].devotion -= 4>>
@@ -152,21 +144,6 @@
 	<</if>>
 
 <<elseif ($Wardeness != 0) && ($slaves[$i].ID is $Wardeness.ID)>>
-	<<silently>>
-	<<if $slaves[$i].choosesOwnClothes == 1>>
-	<<display "SA chooses own clothes">>
-	<<if ($slaves[$i].devotion <= 20)>>
-		<<set $slaves[$i].devotion -= 5>>
-	<<else>>
-		<<set $slaves[$i].devotion += 1>>
-	<</if>>
-	<</if>>
-	<<display "SA diet">>
-	<<display "SA long term effects">>
-	<<display "SA drugs">>
-	<<display "SA relationships">>
-	<<display "SA rivalries">>
-	<</silently>>
 	<<if ($slaves[$i].health < -80)>>
 	<<set $slaves[$i].health += 20>>
 	<<elseif ($slaves[$i].health < -40)>>
@@ -294,10 +271,31 @@
 	<br><br>
 	<<if $showEWD == 0>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Wardeness in $cellblockName.
+		<<silently>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<<display "SA devotion">>
+		<</silently>>
 	<<else>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Wardeness in $cellblockName.
 		<<if $slaves[$i].choosesOwnClothes == 1>>
 		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
 		<</if>>
 		<<display "SA diet">>
 		<<display "SA long term effects">>
@@ -316,6 +314,15 @@
 	<br>
 	<<if $showEWD == 0>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is confined in $cellblockName.
+		<<silently>>
+		<<display [[SA stay confined]]>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<<display "SA devotion">>
+		<</silently>>
 	<<else>>
 		''__@@color:pink;$slaves[$i].slaveName@@__''
 		<<display [[SA stay confined]]>>
@@ -343,10 +350,31 @@
 	<br><br>
 	<<if $showEWD == 0>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Wardeness in $cellblockName.
+		<<silently>>
+		<<if $slaves[$i].choosesOwnClothes == 1>>
+		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
+		<</if>>
+		<<display "SA diet">>
+		<<display "SA long term effects">>
+		<<display "SA drugs">>
+		<<display "SA relationships">>
+		<<display "SA rivalries">>
+		<<display "SA devotion">>
+		<</silently>>
 	<<else>>
 		''__@@color:pink;$slaves[$i].slaveName@@__'' is serving as the Wardeness in $cellblockName.
 		<<if $slaves[$i].choosesOwnClothes == 1>>
 		<<display "SA chooses own clothes">>
+		<<if ($slaves[$i].devotion <= 20)>>
+			<<set $slaves[$i].devotion -= 5>>
+		<<else>>
+			<<set $slaves[$i].devotion += 1>>
+		<</if>>
 		<</if>>
 		<<display "SA diet">>
 		<<display "SA long term effects">>


### PR DESCRIPTION
Fixes the double running of "SA chooses own clothes", "SA diet", "SA long term effects", "SA drugs", "SA relationships", "SA rivalries", and "SA devotion" in the "Cellblock Report" if $showEWD != 0>. This is just a quick fix.